### PR TITLE
Remove references to non-existent tests in pom.xml.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="lib" path="lib/yydebug.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="build/classes"/>

--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>jay</groupId>
       <artifactId>yydebug</artifactId>
       <version>0.1</version>
@@ -93,7 +87,6 @@
 
   <build>
     <sourceDirectory>src</sourceDirectory>
-    <testSourceDirectory>test</testSourceDirectory>
     <extensions>
       <extension>
         <groupId>org.apache.maven.wagon</groupId> 


### PR DESCRIPTION
Eclipse complains about this when you try to import.
