### PR TITLE
Deprecating getValueNode for getValue

### DIFF
--- a/src/org/jrubyparser/ast/BreakNode.java
+++ b/src/org/jrubyparser/ast/BreakNode.java
@@ -54,12 +54,17 @@ public class BreakNode extends Node {
     public Object accept(NodeVisitor iVisitor) {
         return iVisitor.visitBreakNode(this);
     }
-    
+
     /**
      * Gets the valueNode.
      * @return Returns a Node
      */
-    public Node getValueNode() {
+    public Node getValue() {
         return valueNode;
+    }
+
+    @Deprecated
+    public Node getValueNode() {
+        return getValue();
     }
 }

--- a/src/org/jrubyparser/ast/NextNode.java
+++ b/src/org/jrubyparser/ast/NextNode.java
@@ -54,12 +54,17 @@ public class NextNode extends Node {
     public Object accept(NodeVisitor iVisitor) {
         return iVisitor.visitNextNode(this);
     }
-    
+
     /**
      * Gets the valueNode.
      * @return Returns a Node
      */
-    public Node getValueNode() {
+    public Node getValue() {
         return valueNode;
+    }
+    
+    @Deprecated
+    public Node getValueNode() {
+        return getValue();
     }
 }


### PR DESCRIPTION
Just making these two consistent with ReturnNode, and
the style as it exists in the remainder of the codebase.
