### PR TITLE
Argument and Symbol syntax in ReWriteVisitor

### DIFF
--- a/src/org/jrubyparser/rewriter/ReWriteVisitor.java
+++ b/src/org/jrubyparser/rewriter/ReWriteVisitor.java
@@ -391,10 +391,13 @@ public class ReWriteVisitor implements NodeVisitor {
                 print(((ArgumentNode) n).getLexicalName());
             } else {
                 visitNode(n);
-                if (it.hasNext()) print(config.getFormatHelper().getListSeparator());
             }
 
-            if (!it.hasNext()) print(config.getFormatHelper().afterMethodArguments());
+            if (it.hasNext()) {
+                print(config.getFormatHelper().getListSeparator());
+            } else {
+        	print(config.getFormatHelper().afterMethodArguments());
+            }
         }
 
         return null;
@@ -1514,7 +1517,7 @@ public class ReWriteVisitor implements NodeVisitor {
     }
 
     public Object visitSymbolNode(SymbolNode symbol) {
-        print(symbol.getLexicalName());
+        print(":" + symbol.getLexicalName());
         return null;
     }
     


### PR DESCRIPTION
The visitArgsNode method adds separators to ArgumentNodes. The
visitSymbolNode method prepends a colon to the symbol name.
