### PR TITLE
Update README.md to reflect code change

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ public class ParseSomething {
 }
 
 ```
-In the above code, `CompatVersion` is an enum which can be `RUBY1_8`,`RUBY1_9`, or `RUBY2_0`. ParserConfiguration takes
+In the above code, `CompatVersion` is an enum which can be `RUBY1_8`,`RUBY1_9`, `RUBY2_0`, or `RUBY2_3`. ParserConfiguration takes
 several options, including linenumber, version, and optionally a static scope and can be configured with additional information about syntax gathering if necessary. 
 
 ## Ruby


### PR DESCRIPTION
As you can see in [CompatVersion](https://github.com/jruby/jruby-parser/blob/4d408aab70549c75a61eee7e08528738d748254a/src/org/jrubyparser/CompatVersion.java), JRuby-Parser now supports 2.3.