### PR TITLE
gemspec: Drop has_rdoc, rubyforge_project

### DIFF
--- a/jruby-parser.gemspec
+++ b/jruby-parser.gemspec
@@ -15,10 +15,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{A Gem for syntactically correct parse trees of Ruby source}
   s.description = %q{A Gem for syntactically correct parse trees of Ruby source}
 
-  s.rubyforge_project = "jruby-parser"
-
   s.files         = files
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ["lib"]
-  s.has_rdoc      = true
 end


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436