### PR TITLE
Ruby 2_3 support. Added suport for the squiggly heredoc.

### DIFF
--- a/src/org/jrubyparser/lexer/Lexer.java
+++ b/src/org/jrubyparser/lexer/Lexer.java
@@ -860,9 +860,11 @@ public class Lexer {
     private int hereDocumentIdentifier() throws IOException {
         int c = src.read(); 
         int term;
+        char char_for_unread = '\u0000';
 
         int func = 0;
-        if (c == '-') {
+        if (c == '-' || c == '~') {
+            char_for_unread = (char)c;
             c = src.read();
             func = STR_FUNC_INDENT;
         }
@@ -889,8 +891,8 @@ public class Lexer {
         } else {
             if (!isIdentifierChar(c)) {
                 src.unread(c);
-                if ((func & STR_FUNC_INDENT) != 0) {
-                    src.unread('-');
+                if ((func & STR_FUNC_INDENT) != 0 && char_for_unread != '\u0000') {
+                    src.unread(char_for_unread);
                 }
                 return 0;
             }

--- a/src/org/jrubyparser/rewriter/ReWriteVisitor.java
+++ b/src/org/jrubyparser/rewriter/ReWriteVisitor.java
@@ -1529,7 +1529,8 @@ public class ReWriteVisitor implements NodeVisitor {
 
     private boolean stringIsHereDocument(StrNode n) {
         return sourceRangeEquals(getStartOffset(n) + 1, getStartOffset(n) + 3, "<<")
-                || sourceRangeEquals(getStartOffset(n), getStartOffset(n) + 3, "<<-");
+                || sourceRangeEquals(getStartOffset(n), getStartOffset(n) + 3, "<<-")
+                || sourceRangeEquals(getStartOffset(n), getStartOffset(n) + 3, "<<~");
     }
 
     protected char getSeparatorForSym(Node n) {


### PR DESCRIPTION
Added suport for the squiggly heredoc (<<~):

```
str = <<~HEREDOC
   This is a sample
   multiline text.
HEREDOC
```