### PR TITLE
Replaced /bin/sh to /bin/bash

### DIFF
--- a/bin/generate_parser
+++ b/bin/generate_parser
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Run from your JRuby home directory....More smarts needed here.
 


### PR DESCRIPTION
The */bin/sh* usually is a symbolic link that point to the default shell for Linux distribution, but not always it is bash. For example in latest Kbuntu the default shell is a 'dash' shell, for this reason the command *bin/generate_parser* reports error as below:
```
./bin/generate_parser Ruby23Parser Ruby23
Generating Parser 'Ruby23Parser' w/ YYTable prefix of 'Ruby23'
./bin/generate_parser: 35: pushd: not found
./bin/generate_parser: 38: cannot open skeleton.parser: No such file
/usr/bin/ruby: No such file or directory -- ../../../../bin/patch_parser.rb (LoadError)
/usr/bin/ruby: No such file or directory -- ../../../../bin/optimize_parser.rb (LoadError)
./bin/generate_parser: 46: popd: not found
```
Reason for this is that the *pushd* and *popd* commands there are specific for the bash shell.
Solution for this issue is in current pull request.