### PR TITLE
Ruby 2_3 support. Add support for a StrNode type for the $1 attribute.

### DIFF
--- a/src/org/jrubyparser/parser/Ruby23Parser.java
+++ b/src/org/jrubyparser/parser/Ruby23Parser.java
@@ -3814,7 +3814,11 @@ states[432] = new ParserState() {
 };
 states[433] = new ParserState() {
   public Object execute(ParserSupport support, Lexer lexer, Object yyVal, Object[] yyVals, int yyTop) {
-                    yyVal = new StrNode(((Token)yyVals[-1+yyTop]).getPosition(), (String) ((Token)yyVals[0+yyTop]).getValue());
+                    if (yyVals[0+yyTop] instanceof StrNode) {
+                        yyVal = ((StrNode)yyVals[0+yyTop]);
+                    } else {
+                        yyVal = new StrNode(((Token)yyVals[-1+yyTop]).getPosition(), (String) ((Token)yyVals[0+yyTop]).getValue());
+                    }
     return yyVal;
   }
 };
@@ -4708,7 +4712,7 @@ states[604] = new ParserState() {
   }
 };
 }
-					// line 2268 "Ruby23Parser.y"
+					// line 2272 "Ruby23Parser.y"
 
     /** The parse method use an lexer stream and parse it to an AST node 
      * structure
@@ -4740,4 +4744,4 @@ states[604] = new ParserState() {
         return support.getResult();
     }
 }
-					// line 8919 "-"
+					// line 8923 "-"

--- a/src/org/jrubyparser/parser/Ruby23Parser.y
+++ b/src/org/jrubyparser/parser/Ruby23Parser.y
@@ -1662,7 +1662,11 @@ strings         : string {
 
 // [!null]
 string          : tCHAR {
-                    $$ = new StrNode($<Token>0.getPosition(), (String) $1.getValue());
+                    if ($<Object>1 instanceof StrNode) {
+                        $$ = $<StrNode>1;
+                    } else {
+                        $$ = new StrNode($<Token>0.getPosition(), (String) $1.getValue());
+                    }
                 }
                 | string1 {
                     $$ = $1;


### PR DESCRIPTION
During parsing the `/home/piotr/.rvm/rubies/ruby-2.6.6/lib/ruby/2.6.0/fileutils.rb:157` for this statement:
`dir.chomp(?/)`

I got an exception:

`java.lang.ClassCastException: org.jrubyparser.ast.StrNode cannot be cast to org.jrubyparser.lexer.Token
	at org.jrubyparser.parser.Ruby23Parser$316.execute(Ruby23Parser.java:3817)
	at org.jrubyparser.parser.Ruby23Parser.yyparse(Ruby23Parser.java:1598)
	at org.jrubyparser.parser.Ruby23Parser.yyparse(Ruby23Parser.java:1488)
	at org.jrubyparser.parser.Ruby23Parser.parse(Ruby23Parser.java:4738)
	at org.netbeans.modules.ruby.RubyParser.parseBuffer(RubyParser.java:566)
	at org.netbeans.modules.ruby.RubyParser.parse(RubyParser.java:133)
	at org.netbeans.modules.parsing.impl.TaskProcessor.callParse(TaskProcessor.java:598)
	at org.netbeans.modules.parsing.impl.SourceCache.getResult(SourceCache.java:228)
	at org.netbeans.modules.parsing.impl.TaskProcessor$RequestPerformer.run(TaskProcessor.java:775)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:279)
	at org.netbeans.modules.parsing.impl.TaskProcessor$RequestPerformer.execute(TaskProcessor.java:702)
[catch] at org.netbeans.modules.parsing.impl.TaskProcessor$CompilationJob.run(TaskProcessor.java:663)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at org.openide.util.RequestProcessor$Task.run(RequestProcessor.java:1418)
	at org.netbeans.modules.openide.util.GlobalLookup.execute(GlobalLookup.java:45)
	at org.openide.util.lookup.Lookups.executeWith(Lookups.java:278)
	at org.openide.util.RequestProcessor$Processor.run(RequestProcessor.java:2033)
`

In this `((Token)yyVals[0+yyTop]).getValue());` statement we expect that item from array will have a Token type but in this case it have a type StrNode. For that situation my fix try to return this item with his type.